### PR TITLE
fix bug - issue #40 - can't delete after typing a dot

### DIFF
--- a/dime/Components/Transactions/NumberPad.swift
+++ b/dime/Components/Transactions/NumberPad.swift
@@ -347,10 +347,10 @@ struct NumberPadTextView: View {
         } else {
             switch decimalValuesAssigned {
                 case .none:
+                    isEditingDecimal = false
                     return
                 case .first:
                     price = Double(Int(price))
-                    isEditingDecimal = false
                     decimalValuesAssigned = .none
                 case .second:
                     price = Double(Int(price * 10)) / 10


### PR DESCRIPTION
I fixed the bug where you are not able to delete the dot if it is the last character.


https://github.com/rarfell/dimeApp/assets/128280660/324c6ff4-662a-4548-8aef-83aead571059

