### PR TITLE
Fix: #72 Cannot delete 0 or decimal at last digit

### DIFF
--- a/app/dime/Components/Transactions/NumberPad.swift
+++ b/app/dime/Components/Transactions/NumberPad.swift
@@ -336,7 +336,7 @@ struct NumberPadTextView: View {
            .background(Color.SecondaryBackground, in: Circle())
            .contentShape(Circle())
        }
-       .disabled(price == 0)
+       .disabled(price == 0 && !isEditingDecimal)
    }
 
     public func deleteLastDigit() {


### PR DESCRIPTION
Fixed bug: Cannot delete 0 or decimal at last digit #72

Added condition to ignore disable when price is 0 but dealing with decimal


https://github.com/user-attachments/assets/fc4e556d-0874-48c5-a828-cd498c838693


